### PR TITLE
feat: add contents of the message box to the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Use Azure/OpenAI API to review Git changes, generate conventional commit message
 1. Ensure that you have installed and enabled the "AI Commit" extension.
 2. In VSCode settings, locate the "ai-commit" configuration options and configure them as needed.
 3. Make changes in your project and add the changes to the staging area (git add).
-4. Next to the commit message input box in the "Source Control" panel, click the "AI Commit" icon button. After clicking, the extension will generate a commit message and populate it in the input box.
-5. Review the generated commit message, and if you are satisfied, proceed to commit your changes.
+4. Optionally supply any additional context to the AI by adding text to the commit message input box in the "Source Control" panel.
+5. Next to the commit message input box in the "Source Control" panel, click the "AI Commit" icon button. After clicking, the extension will generate a commit message and populate it in the input box.
+6. Review the generated commit message, and if you are satisfied, proceed to commit your changes.
 
 > **Note**\
 > If the code exceeds the maximum token length, consider adding it to the staging area in batches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-commit",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-commit",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.0.4",

--- a/src/generate-commit-msg.ts
+++ b/src/generate-commit-msg.ts
@@ -13,8 +13,8 @@ import { ProgressHandler } from './utils';
  * @param {string} diff - The diff string representing changes to be committed.
  * @returns {Promise<Array<{ role: string, content: string }>>} - A promise that resolves to an array of messages for the chat completion.
  */
-const generateCommitMessageChatCompletionPrompt = async (diff: string) => {
-  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt();
+const generateCommitMessageChatCompletionPrompt = async (diff: string, extras: string) => {
+  const INIT_MESSAGES_PROMPT = await getMainCommitPrompt(extras);
   const chatContextAsCompletionRequest = [...INIT_MESSAGES_PROMPT];
 
   chatContextAsCompletionRequest.push({
@@ -85,7 +85,8 @@ export async function generateCommitMsg(arg) {
         }
 
         progress.report({ message: 'Analyzing changes...' });
-        const messages = await generateCommitMessageChatCompletionPrompt(diff);
+        const extras = scmInputBox.value;
+        const messages = await generateCommitMessageChatCompletionPrompt(diff, extras);
 
         progress.report({ message: 'Generating commit message...' });
         try {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -6,7 +6,7 @@ import { ConfigKeys, ConfigurationManager } from './config';
  * @param {string} language - The language to be used in the prompt.
  * @returns {Object} - The main prompt object containing role and content.
  */
-const INIT_MAIN_PROMPT = (language: string) => ({
+const INIT_MAIN_PROMPT = (language: string, extras: string) => ({
   role: 'system',
   content:
     ConfigurationManager.getInstance().getConfig<string>(ConfigKeys.SYSTEM_PROMPT) ||
@@ -78,6 +78,7 @@ You will act as a git commit message generator. When receiving a git diff, you w
 3. NO additional text or explanations
 4. NO questions or comments
 5. NO formatting instructions or metadata
+${extras ? `6. VERY IMPORTANT! ${extras}` : ''}
 
 ## Examples
 
@@ -100,7 +101,8 @@ OUTPUT:
 - rename port variable to uppercase (PORT) to follow constant naming convention
 - add environment variable port support for flexible deployment
 
-Remember: All output MUST be in ${language} language. You are to act as a pure commit message generator. Your response should contain NOTHING but the commit message itself.`
+Remember: All output MUST be in ${language} language. You are to act as a pure commit message generator. Your response should contain NOTHING but the commit message itself.
+`
 });
 
 /**
@@ -108,9 +110,9 @@ Remember: All output MUST be in ${language} language. You are to act as a pure c
  *
  * @returns {Promise<Array<Object>>} - A promise that resolves to an array of prompts.
  */
-export const getMainCommitPrompt = async () => {
+export const getMainCommitPrompt = async (extras: string) => {
   const language = ConfigurationManager.getInstance().getConfig<string>(
     ConfigKeys.AI_COMMIT_LANGUAGE
   );
-  return [INIT_MAIN_PROMPT(language)];
+  return [INIT_MAIN_PROMPT(language, extras)];
 };


### PR DESCRIPTION
Sometimes it's useful to supply some additional instructions to the model for generating the commit message as it can misinterpret the code change. This PR appends the text already entered in the message box to the prompt.