### PR TITLE
fix: 清理 commit 消息中的 think 标签内容

### DIFF
--- a/src/generate-commit-msg.ts
+++ b/src/generate-commit-msg.ts
@@ -125,8 +125,9 @@ export async function generateCommitMsg(arg) {
           commitMessage = await ChatGPTAPI(messages as ChatCompletionMessageParam[]);
         }
 
-
         if (commitMessage) {
+          // 清理 think 标签内容
+          commitMessage = commitMessage.replace(/<think>.*?<\/think>/gs, '').trim();
           scmInputBox.value = commitMessage;
         } else {
           throw new Error('Failed to generate commit message');


### PR DESCRIPTION
移除生成的 commit 消息中包含的 think 标签内容，确保提交信息更加简洁和清晰。#24