### PR TITLE
fix: validate API key based on selected AI provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,19 +21,41 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     });
 
-    const apiKey = configManager.getConfig<string>('OPENAI_API_KEY');
-    if (!apiKey) {
-      const result = await vscode.window.showWarningMessage(
-        'OpenAI API Key not configured. Would you like to configure it now?',
-        'Yes',
-        'No'
-      );
-
-      if (result === 'Yes') {
-        await vscode.commands.executeCommand(
-          'workbench.action.openSettings',
-          'ai-commit.OPENAI_API_KEY'
+    // Check API key based on configured AI provider
+    const aiProvider = configManager.getConfig<string>('AI_PROVIDER', 'openai');
+    
+    if (aiProvider === 'gemini') {
+      const geminiApiKey = configManager.getConfig<string>('GEMINI_API_KEY');
+      if (!geminiApiKey) {
+        const result = await vscode.window.showWarningMessage(
+          'Gemini API Key not configured. Would you like to configure it now?',
+          'Yes',
+          'No'
         );
+
+        if (result === 'Yes') {
+          await vscode.commands.executeCommand(
+            'workbench.action.openSettings',
+            'ai-commit.GEMINI_API_KEY'
+          );
+        }
+      }
+    } else {
+      // Default to OpenAI provider
+      const openaiApiKey = configManager.getConfig<string>('OPENAI_API_KEY');
+      if (!openaiApiKey) {
+        const result = await vscode.window.showWarningMessage(
+          'OpenAI API Key not configured. Would you like to configure it now?',
+          'Yes',
+          'No'
+        );
+
+        if (result === 'Yes') {
+          await vscode.commands.executeCommand(
+            'workbench.action.openSettings',
+            'ai-commit.OPENAI_API_KEY'
+          );
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
Previously only checked OpenAI key even when Gemini was configured